### PR TITLE
chore: sets up ci (github actions)

### DIFF
--- a/.dependency-cruiser.json
+++ b/.dependency-cruiser.json
@@ -33,7 +33,7 @@
       "name": "no-orphans",
       "severity": "warn",
       "comment": "Warn in case there's orphans",
-      "from": { "orphan": true },
+      "from": { "orphan": true, "pathNot": "^src/script/test/features" },
       "to": {}
     },
     {
@@ -41,7 +41,11 @@
       "severity": "warn",
       "comment": "Warn in case there's orphans",
       "from": { "path": "^src/script/wordywordy\\.js$" },
-      "to": { "reachable": false, "pathNot": "\\.spec\\.js$" }
+      "to": {
+        "reachable": false,
+        "path": "^src/",
+        "pathNot": "^src/script/test/"
+      }
     },
     {
       "name": "no-deprecated-core",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,75 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "*/**.md"
+      - "*/**.txt"
+  pull_request:
+    paths-ignore:
+      - "*/**.md"
+      - "*/**.txt"
+  workflow_dispatch:
+
+env:
+  CI: true
+  NODE_LATEST: 18.x
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: build-${{hashFiles('package.json')}}
+          restore-keys: |
+            build-
+      # - name: dump some variables
+      #   run: |
+      #     echo '## github object' >> $GITHUB_STEP_SUMMARY
+      #     echo '```json' >> $GITHUB_STEP_SUMMARY
+      #     echo '${{toJSON(github)}}' >> $GITHUB_STEP_SUMMARY
+      #     echo '```' >> $GITHUB_STEP_SUMMARY
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{env.NODE_LATEST}}
+      - run: npm install
+      - run: npm run depcruise
+      - run: npm run format:check
+      - run: npm run lint
+      - run: npm run test:cover
+      - run: npm run build
+      - name: emit coverage results to step summary
+        if: always()
+        run: |
+          echo '## Code coverage' >> $GITHUB_STEP_SUMMARY
+          node tools/istanbul-json-summary-to-markdown.mjs < coverage/coverage-summary.json >> $GITHUB_STEP_SUMMARY
+      - name: on pushes to the default branch emit full depcruise results to step summary
+        if: always() && github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
+        run: |
+          yarn --silent depcruise --output-type markdown >> $GITHUB_STEP_SUMMARY
+          echo '## Visual overview' >> $GITHUB_STEP_SUMMARY
+          echo '```mermaid' >> $GITHUB_STEP_SUMMARY
+          yarn --silent depcruise --exclude "(test|.spec.js$)" --include-only "^(src/script)" --output-type mermaid >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+      - name: on pull requests emit depcruise results + diff graph to step summary
+        if: always() && github.event_name == 'pull_request' && github.ref_name != github.event.repository.default_branch
+        run: |
+          yarn --silent depcruise --output-type markdown >> $GITHUB_STEP_SUMMARY
+          echo '## Visual diff' >> $GITHUB_STEP_SUMMARY
+          echo '```mermaid' >> $GITHUB_STEP_SUMMARY
+          SHA=${{github.event.pull_request.base.sha}} yarn --silent depcruise:graph:diff:mermaid >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .DS_Store
 *.swp
 *.swo
-.nyc_output
+coverage/
 .project
 .settings/*
 node_modules

--- a/Makefile
+++ b/Makefile
@@ -290,7 +290,6 @@ clean-generated-sources:
 somewhatclean: clean-generated-sources
 	rm -rf $(BUILDDIR)/index.html
 	rm -rf $(BUILDDIR)/service-worker.js
-	rm -rf coverage
 	rm -rf $(PRODDIRS)
 	rm -rf testcoverage-report
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "screenfull": "^5.2.0"
   },
   "devDependencies": {
+    "c8": "7.12.0",
     "chai": "4.3.6",
     "dependency-cruiser": "11.16.1",
     "eslint": "8.24.0",
@@ -16,24 +17,25 @@
     "eslint-plugin-security": "1.5.0",
     "mocha": "10.0.0",
     "npm-run-all": "4.1.5",
-    "nyc": "15.1.0",
     "prettier": "2.7.1",
     "sass": "1.55.0",
     "uglify-js": "3.17.2",
-    "upem": "7.3.0"
+    "upem": "7.3.0",
+    "watskeburt": "0.7.0"
   },
   "scripts": {
     "build": "make clean dev-build install",
     "check": "npm-run-all --parallel depcruise lint format:check test:cover ",
     "codeclimate-cover-submit": "node node_modules/codeclimate-test-reporter/bin/codeclimate.js < coverage/lcov.info",
-    "depcruise": "depcruise -v -- src/script",
+    "depcruise": "depcruise src/script --config .dependency-cruiser.json",
     "depcruise:graph": "depcruise -v -M amd -x \"test\" -T dot src | dot -T svg | tee dependency-graph.svg | depcruise-wrap-stream-in-html > tmp_deps.html",
+    "depcruise:graph:diff:mermaid": "depcruise src/script --cache --include-only '^(src/script)' --config --output-type mermaid --output-to - --reaches \"$(watskeburt $SHA -T regex)\"",
     "format": "prettier --loglevel warn --write \"**/*.md\" \"src/script/**/*.js\" \"src/style/*.{scss,css}\"",
     "format:check": "prettier --loglevel warn --check \"**/*.md\" \"src/script/**/*.js\" \"src/style/*.{scss,css}\"",
     "lint": "eslint src/script",
     "lint:fix": "eslint --fix src/script",
     "test": "mocha -R dot src/script/test/",
-    "test:cover": "nyc npm test",
+    "test:cover": "c8 --check-coverage --statements 100 --branches 98 --functions 100 --lines 100 --exclude \"**/*.spec.js\" --reporter text-summary --reporter html --reporter json-summary npm test",
     "update-dependencies": "npm-run-all upem:update upem:install build format lint:fix check",
     "upem-outdated": "npm outdated --json --long | upem --dry-run",
     "upem:update": "npm outdated --json | upem",

--- a/tools/istanbul-json-summary-to-markdown.mjs
+++ b/tools/istanbul-json-summary-to-markdown.mjs
@@ -1,0 +1,45 @@
+function formatMetric(pCoverageMetric) {
+  return `${pCoverageMetric.pct.toFixed(1)}%|${pCoverageMetric.covered}/${
+    pCoverageMetric.total
+  }|${pCoverageMetric.skipped} skipped`;
+}
+
+function formatSummary(pCoverageSummary) {
+  return (
+    `|||||\n` +
+    `|:--|--:|:--:|--:|\n` +
+    `|**Statements**|${formatMetric(pCoverageSummary.total.statements)}|\n` +
+    `|**Branches**|${formatMetric(pCoverageSummary.total.branches)}|\n` +
+    `|**Functions**|${formatMetric(pCoverageSummary.total.functions)}|\n` +
+    `|**Lines**|${formatMetric(pCoverageSummary.total.lines)}|\n`
+  );
+}
+/**
+ * Takes the output from the instanbul json-summary reporter (in a readStream),
+ * formats it in a markdown table and writes it to the provided writeStream
+ *
+ * @param {readStream} pStream stream to read the JSON from
+ * @param {writeStream} pOutStream stream to write the markdown to
+ */
+function main(pInStream, pOutStream) {
+  let lBuffer = "";
+
+  pInStream
+    .on("end", () => {
+      pOutStream.write(formatSummary(JSON.parse(lBuffer)));
+      pOutStream.end();
+    })
+    .on(
+      "error",
+      /* c8 ignore start */
+      (pError) => {
+        process.stderr.write(`${pError}\n`);
+      }
+      /* c8 ignore stop */
+    )
+    .on("data", (pChunk) => {
+      lBuffer += pChunk;
+    });
+}
+
+main(process.stdin, process.stdout);


### PR DESCRIPTION
## Description

- sets up a basic ci workflow in GitHub actions
- replace `nyc` with `c8` (because we're used to how it works from other repo's)
- sets up some scripts within the repo to emit stuff to the workflow step summary
- updates dependency-cruiser config to reflect some specifics of this repo

## Motivation and Context

- we need a CI in order to colaboratively (, reliably, transparently) work on the code of this repo.

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The GPLv3 license](https://github.com/sverweij/wordywordy/blob/master/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/wordywordy/blob/master/.github/CONTRIBUTING.md).
